### PR TITLE
Don't disenchant town teleport guild cloaks

### DIFF
--- a/Disenchanting.lua
+++ b/Disenchanting.lua
@@ -35,6 +35,7 @@ local notDEable = {
 	["63353"] = true, -- Shroud of Cooperation (H)
 	["63206"] = true, -- Wrap of Unity (A)
 	["63207"] = true, -- Wrap of Unity (H)
+	["69209"] = true, -- Illustrious Guild Tabard
 }
 
 local GS, L = Panda.GS, Panda.locale


### PR DESCRIPTION
Following up on #44, here are a few more guild rewards that are _technically_ disenchantable, but only if you really want to pay 112g for a Small Glowing Shard.
