### PR TITLE
Exclude BoA items from disenchant panel when showBOP is false

### DIFF
--- a/Disenchanting.lua
+++ b/Disenchanting.lua
@@ -19,6 +19,7 @@ local function IsBound(bag, slot)
 	tip:SetBagItem(bag, slot)
 	for i=1,30 do
 		if tip.L[i] == L.Soulbound then return true end
+		if tip.L[i] == L["Battle.net Account Bound"] then return true end
 	end
 end
 
@@ -206,7 +207,7 @@ frame:SetScript("OnShow", function(self)
 	BOP:SetScript("OnClick", function() showBOP = not showBOP; OnEvent(self) end)
 
 	local BOPlabel = cfs(BOP, nil, "ARTWORK", "GameFontNormalSmall", "LEFT", BOP, "RIGHT", 5, 0)
-	BOPlabel:SetText("Show soulbound items")
+	BOPlabel:SetText("Show soulbound/BoA items")
 
 	self:SetScript("OnEvent", OnEvent)
 	self:RegisterEvent("BAG_UPDATE")


### PR DESCRIPTION
This is a small change to exclude items with "Battle.net Account Bound" in the tooltip when showBOP is false.  I also changed the label on the checkbox to reflect this.

The impetus for this is me melting my [Spear of Xu'en](http://www.wowhead.com/item=89685), an iLevel 463 Archaeology staff because I wasn't paying attention one night and BoA show up in the panel as BoEs right now.

Thankfully I got it back via a GM,but I can't imagine a use case where you'd want to be able to melt BoAs more easily than you can melt soulbound items.
